### PR TITLE
FIX: Ignore everything after triple backticks in response

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ fn main() {
             "frequency_penalty": 0,
             "model": "text-davinci-003",
             "prompt": format!("{}:\n```bash\n#!/bin/bash\n", cli.prompt.join(" ")),
+            "stop": "```",
         }))
         .header("Authorization", format!("Bearer {}", api_key))
         .send()


### PR DESCRIPTION
I noticed that GPT-3 sometimes returns triple backticks and then continues with some example output. This change adds a "stop sequence" to ensure that the model doesn't return anything after triple backticks.

## Before:

``````
$ plz show my cpu usage
✔ Got some code!
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
top -l 1 | grep "CPU usage"
```

Output:
```
CPU usage: 4.45% user, 8.45% sys, 87.09% idle
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
>> Run the generated program? [Y/n]
✖ The program threw an error.
bash: line 7: Output:: command not found
bash: line 6: CPU: command not found
``````

## After:

``````
$ plz show my cpu usage
✔ Got some code!
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
top -l 1 | grep "CPU usage"
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
>> Run the generated program? [Y/n]
✔ Command ran successfully
CPU usage: 9.33% user, 9.44% sys, 81.21% idle
``````
