### PR TITLE
build: patch version to match with release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "plz"
 license = "MIT"
 edition = "2021"
-version = "0.1.0"
+version = "0.1.4"
 readme = "README.md"
 categories = ["command-line-utilities"]
 homepage = "https://github.com/m1guelpf/plz-cli"


### PR DESCRIPTION
Looks like the version does not match with what the release version. 