### PR TITLE
add write_to_history function and a bit of refactoring

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,7 @@ impl Config {
             .map_or((), |mut file| {
                 file.write_all(format!("{code}\n").as_bytes())
                     .unwrap_or_else(|_| {
-                        std::process::exit(1);
+                        exit(1);
                     });
             });
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,36 @@
+use std::{env, error::Error, io::Write, process::exit};
+
+use colored::Colorize;
+
+pub struct Config {
+    pub api_key: String,
+    pub shell: String,
+}
+
+impl Config {
+    pub fn new() -> Result<Self, Box<dyn Error>> {
+        let api_key = env::var("OPENAI_API_KEY").unwrap_or_else(|_| {
+            println!("{}", "This program requires an OpenAI API key to run. Please set the OPENAI_API_KEY environment variable. https://github.com/m1guelpf/plz-cli#usage".red());
+            exit(1);
+        });
+
+        let shell = env::var("SHELL").unwrap_or_else(|_| "".to_string());
+
+        Ok(Self { api_key, shell })
+    }
+
+    pub fn write_to_history(&self, code: &str) -> std::io::Result<()> {
+        let history_file = match self.shell.as_str() {
+            "/bin/bash" => std::env::var("HOME").unwrap() + "/.bash_history",
+            "/bin/zsh" => std::env::var("HOME").unwrap() + "/.zsh_history",
+            _ => return Ok(()),
+        };
+
+        match std::fs::OpenOptions::new().append(true).open(history_file) {
+            Ok(mut file) => match file.write_all(format!("{}\n", code).as_bytes()) {
+                _ => return Ok(()),
+            },
+            _ => return Ok(()),
+        };
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
-use std::{env, error::Error, io::Write, process::exit};
-
 use colored::Colorize;
+use std::{env, error::Error, io::Write, process::exit};
 
 pub struct Config {
     pub api_key: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::process::Command;
 use bat::PrettyPrinter;
 use clap::Parser;
 use colored::Colorize;
+use config::Config;
 use question::{Answer, Question};
 use reqwest::blocking::Client;
 use serde_json::json;
@@ -25,8 +26,7 @@ struct Cli {
 
 fn main() {
     let cli = Cli::parse();
-
-    let config = config::Config::new().unwrap();
+    let config = Config::new();
 
     let client = Client::new();
     let mut spinner = Spinner::new(Spinners::BouncingBar, "Generating your command...".into());
@@ -133,8 +133,6 @@ fn main() {
 
         println!("{}", String::from_utf8_lossy(&output.stdout));
 
-        config.write_to_history(code.as_str()).unwrap_or_else(|_| {
-            std::process::exit(1);
-        });
+        config.write_to_history(code.as_str());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,10 +26,7 @@ struct Cli {
 fn main() {
     let cli = Cli::parse();
 
-    let config = config::Config::new().unwrap_or_else(|_| {
-        println!("{}", "Failed to load config file.".red());
-        std::process::exit(1);
-    });
+    let config = config::Config::new().unwrap();
 
     let client = Client::new();
     let mut spinner = Spinner::new(Spinners::BouncingBar, "Generating your command...".into());
@@ -41,8 +38,6 @@ fn main() {
     } else {
         ""
     };
-
-    println!("{}{}", cli.prompt.join(" "), os_hint);
 
     let response = client
         .post("https://api.openai.com/v1/completions")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
 #![warn(clippy::all, clippy::pedantic, clippy::nursery)]
 
-use std::process::Command;
-
 use bat::PrettyPrinter;
 use clap::Parser;
 use colored::Colorize;
@@ -10,6 +8,7 @@ use question::{Answer, Question};
 use reqwest::blocking::Client;
 use serde_json::json;
 use spinners::{Spinner, Spinners};
+use std::process::Command;
 
 mod config;
 


### PR DESCRIPTION
- adds write_to_history function, which writes to the appropriate shell history file if found. Currently only supports zsh and bash
- move some config code to a separate file