### PR TITLE
Add a statically-linked musl file to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,60 @@ jobs:
           name: output-artifact
           path: outputs
 
+  linux-musl:
+    name: Musl build for Linux
+    runs-on: ubuntu-latest
+    needs: [version_bump]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: pkg-version
+
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Install Rust musl toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-musl
+          override: true
+          profile: minimal
+
+      - name: Install gcc-musl compiler
+        shell: bash
+        run: |
+          sudo apt-get install musl-tools
+          musl-gcc --version || true
+
+      - name: Build
+        run: cargo build --release --target=x86_64-unknown-linux-musl
+
+      - name: "Move to outputs/ folder"
+        run: |
+          mkdir outputs
+          cp target/x86_64-unknown-linux-musl/release/plz outputs/plz-linux-musl-x86_64
+
+      - name: Upload to temporary storage
+        uses: actions/upload-artifact@master
+        with:
+          name: output-artifact
+          path: outputs
+
   macos:
     name: Build for Mac
     runs-on: macos-11
@@ -163,7 +217,7 @@ jobs:
   release:
     name: Release assets
     runs-on: ubuntu-latest
-    needs: [windows, linux, macos]
+    needs: [windows, linux, linux-musl, macos]
 
     steps:
       - name: Download from temporary storage


### PR DESCRIPTION
Having a statically linked binary is useful for being able to use tool in systems with old glibc versions.