### PR TITLE
Write command to history early

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,7 @@ fn main() {
     };
 
     if should_run {
+        config.write_to_history(code.as_str());
         spinner = Spinner::new(Spinners::BouncingBar, "Executing...".into());
 
         // run command and print output and error
@@ -131,7 +132,5 @@ fn main() {
         );
 
         println!("{}", String::from_utf8_lossy(&output.stdout));
-
-        config.write_to_history(code.as_str());
     }
 }


### PR DESCRIPTION
If a command execution is terminated by <kbd>Ctrl</kbd>+<kbd>C</kbd> or execution fails, it is currently not added to history. In my opinion, it should still be added to history.

Use case: I recently experienced that the AI returned a `find / …`. I liked the rest of the command, but I just wanted to search in the current directory. I therefore terminated the execution and wanted to adjust the line. Unfortunately, the command didn't appear in my history, so I couldn't press the <kbd>↑</kbd> key. I had to copy the command with my mouse from the terminal and then paste it.