### PR TITLE
docs: add homebrew installation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ You can install `plz` by running the following command in your terminal.
 curl -fsSL https://raw.githubusercontent.com/m1guelpf/plz-cli/main/install.sh | sh -
 ```
 
+### Homebrew
+
+You can also install `plz` using [Homebrew](https://brew.sh/).
+
+```sh
+$ brew install plz-cli
+```
+
 You may need to close and reopen your terminal after installation. Alternatively, you can download the binary corresponding to your OS from the [latest release](https://github.com/m1guelpf/plz-cli/releases/latest).
 
 ## Usage


### PR DESCRIPTION
Now installing via [brew](http://brew.sh/) is possible:

```
$ brew install plz-cli
==> Fetching plz-cli
==> Downloading https://ghcr.io/v2/homebrew/core/plz-cli/manifests/0.1.6
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/plz-cli/blobs/sha256:52f9b33a7c71716c449f149917edded90c289e4b4b3a686915e7a2d215209608
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:52f9b33a7c71716c449f149917edded90c289e4b4b3a686915e7a2d215209608?se=2023-01-17T00%3A55%3A00Z&sig=k5XDtl4MLuiUAmfb7aXJwuuURYCZIlBmTvonwMqEL14%3D&
######################################################################## 100.0%
==> Pouring plz-cli--0.1.6.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/plz-cli/0.1.6: 7 files, 7.7MB
```