### PR TITLE
Update model to gpt-3.5-turbo-instruct

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
             "max_tokens": 1000,
             "presence_penalty": 0,
             "frequency_penalty": 0,
-            "model": "text-davinci-003",
+            "model": "gpt-3.5-turbo-instruct",
             "prompt": build_prompt(&cli.prompt.join(" ")),
         }))
         .header("Authorization", format!("Bearer {}", config.api_key))


### PR DESCRIPTION
`text-davinci-003` has been deprecated since Jan 04 and the CLI is currently not functioning.

OpenAI recommends `gpt-3.5-turbo-instruct` instead: https://platform.openai.com/docs/deprecations/instructgpt-models

Thanks for the awesome cli :)