### PR TITLE
feat: Update model to gpt-4o-mini and support api model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plz"
-version = "0.1.0"
+version = "0.1.10"
 dependencies = [
  "bat",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "plz"
 license = "MIT"
 edition = "2021"
-version = "0.1.0"
+version = "0.1.10"
 readme = "README.md"
 categories = ["command-line-utilities"]
 homepage = "https://github.com/m1guelpf/plz-cli"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You may need to close and reopen your terminal after installation. Alternatively
 
 ## Usage
 
-`plz` uses [GPT-3](https://beta.openai.com/). To use it, you'll need to grab an API key from [your dashboard](https://beta.openai.com/), and save it to `OPENAI_API_KEY` as follows (you can also save it in your bash/zsh profile for persistance between sessions).
+`plz` uses [GPT-4o-mini](https://platform.openai.com/docs/overview). To use it, you'll need to grab an API key from [your admin api  ](https://platform.openai.com/settings/organization/api-keys), and save it to `OPENAI_API_KEY` as follows (you can also save it in your bash/zsh profile for persistance between sessions).
 
 ```bash
 export OPENAI_API_KEY='sk-XXXXXXXX'
@@ -45,6 +45,15 @@ Options:
   -y, --force    Run the generated program without asking for confirmation
   -h, --help     Print help information
   -V, --version  Print version information
+```
+
+## Model
+
+You can also configure the name of the model to use or change the base URL.
+
+```bash
+export OPENAI_API_MODEL='gpt-XXXXXXXX'    # Default gpt-4o-mini
+export OPENAI_API_BASE='https://XXXXXXXX' # Default https://api.openai.com/v1
 ```
 
 ## Develop

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use std::{env, io::Write, process::exit};
 pub struct Config {
     pub api_key: String,
     pub api_base: String,
+    pub api_model: String,
     pub shell: String,
 }
 
@@ -14,9 +15,10 @@ impl Config {
             exit(1);
         });
         let api_base = env::var("OPENAI_API_BASE").unwrap_or_else(|_| String::from("https://api.openai.com/v1"));
+        let api_model = env::var("OPENAI_API_MODEL").unwrap_or_else(|_| String::from("gpt-4o-mini"));
         let shell = env::var("SHELL").unwrap_or_else(|_| String::new());
 
-        Self { api_key, api_base, shell }
+        Self { api_key, api_base, api_model, shell }
     }
 
     pub fn write_to_history(&self, code: &str) {


### PR DESCRIPTION
OpenAI recommends gpt-4o-mini, as it saves 60% on costs compared to gpt-3.5-turbo-instruct, not to mention having a better score (MMLU) [https://platform.openai.com/docs/pricing](https://platform.openai.com/docs/pricing)

Likewise, the possibility of configuring the model name to be used was added.